### PR TITLE
A Python alternative to the ruby script to generate bootloader_data.c

### DIFF
--- a/upgrade/generate-data.py
+++ b/upgrade/generate-data.py
@@ -1,0 +1,35 @@
+import sys
+import time
+from intelhex import IntelHex
+
+# Check if a file path was provided as an argument
+if len(sys.argv) < 2:
+    print("Usage: python generate_data.py <hex_file>")
+    sys.exit(1)
+
+# Read the hex file using the IntelHex library
+ih = IntelHex()
+ih.loadhex(sys.argv[1])
+
+# Get the start address and data as a list of bytes
+start_address = ih.minaddr()
+data = ih.tobinarray(start=start_address)
+
+# If data is an odd number of bytes, make it even
+if len(data) % 2 != 0:
+    data.append(0xFF)
+
+print(f"Length: {len(data)}")
+print(f"Start address: {start_address}")
+
+# Generate the bootloader_data.c file
+with open("bootloader_data.c", "w") as file:
+    file.write("// This file contains the bootloader data itself and the address to install the bootloader at\n")
+    file.write("// Use generate-data.py to generate these values from a hex file\n")
+    file.write(f"// Generated from {sys.argv[1]} at {time.ctime()}\n\n")
+    file.write(f"const uint16_t bootloader_data[{len(data) // 2}] PROGMEM = {{\n")
+    for i in range(0, len(data), 2):
+        word = (data[i+1] << 8) + data[i] if i+1 < len(data) else data[i]
+        file.write(f"    0x{word:04X},\n")
+    file.write("};\n\n")
+    file.write(f"const uint16_t bootloader_address = {start_address};\n") 

--- a/upgrade/readme.txt
+++ b/upgrade/readme.txt
@@ -14,6 +14,11 @@ Creating an Upgrader
     ruby generate-data.rb my_bootloader.hex
     make clean; make
 
+    OR
+
+    python generate-data.py my_bootloader.hex
+    make clean; make
+
 Next upload the 'upgrade.hex' file generated, via whichever bootloader you're using. If you're using micronucleus and have the command line tool installed: micronucleus --run upgrade.hex
 
 The ruby script requires ruby 1.9 be installed. On Mac OS this is best achieved via Mac Homebrew. The 1.8 version included wont do.


### PR DESCRIPTION
python version of generate-data.rb With the addition of making it output bootloader_data.c with bootloader_data and bootloader_address variables as const